### PR TITLE
Use miro.getClientId()

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Trying to align with the templates available in [this repo](https://github.com/T
 
 # How it works
 
-You can try the plugin durectly using this URL: https://miro.com/oauth/authorize/?response_type=code&client_id=3074457356139930746&redirect_uri=%2Fconfirm-app-install%2F
+You can try the official plugin durectly from [Miro Marketplace](https://miro.com/marketplace/team-topologies/).
 
 Setup the Team Topologies icon from your library
 
@@ -31,7 +31,6 @@ Once the needed shapes are in your whiteboard, you can edit them as much as you 
 You will need Webpack-cli install globally with npm ENV VAR set.
 
 - Run `npm install`
-- Replace `CLIENT_ID` in [`src/config.ts`](src/config.ts) file _(You can get your own *CLIENT_ID* in Miro app settings)_.
 - Run `npm run build` or `npm run watch` to compile the plugin
 
 _development_

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,3 @@
-export const CLIENT_ID = process.env.NODE_ENV == 'production' ? '3074457356139930746' : '3074457355995945552'
 export const PLUGIN_TITLE = process.env.NODE_ENV == 'production' ? 'Team Topologies' : 'TT_Local Run'
 export const LOGO_TT = `<svg version="1.1" id="team_topologies_logo_btn" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 103 103" style="enable-background:new 0 0 339 103;" xml:space="preserve">
 <g>

--- a/src/content-panel.tsx
+++ b/src/content-panel.tsx
@@ -3,7 +3,6 @@ import * as ReactDOM from 'react-dom'
 
 import SVG from 'react-inlinesvg'
 
-import {CLIENT_ID} from 'config'
 import {TEAM_ENUM, TeamElement} from './team-logic/team-static'
 import {TeamFactory} from './team-logic/team-factory'
 
@@ -67,7 +66,7 @@ class Root extends React.Component {
     }
     await miro.board.widgets.create({
       metadata: {
-        [CLIENT_ID]: {
+        [miro.getClientId()]: {
           teamtopology: true,
           teamEnum: TEAM_ENUM[teamElement.getTeamEnum()],
         },

--- a/src/details-panel.tsx
+++ b/src/details-panel.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import PropTypes from 'prop-types'
-import {CLIENT_ID} from 'config'
 import ReactMarkdown from 'react-markdown'
 
 import {TEAM_ENUM} from 'team-logic/team-static'


### PR DESCRIPTION
## What happened

- Replaced hardcoded Client ID with SDK `miro.getClientId()` method.
- Update ReadMe.md to remove ClientId instance & add MarketPlace plugin URL instead

## How to test?

- Use netlify preview url (https://deploy-preview-5--miro-team-topologies.netlify.app) with a test app.
- Tested from Ngrok and Netlify, fully working (all features tested)

## Proof of work

- No more client id:
![image](https://user-images.githubusercontent.com/77609814/123500920-abf90300-d66b-11eb-840d-1829fd8ef7c0.png)

- Tested with netlify preview url
![image](https://user-images.githubusercontent.com/77609814/123500904-94217f00-d66b-11eb-8bde-b1d88b50611a.png)
